### PR TITLE
Fixing validation that leads to an avoidance of SNAT creation

### DIFF
--- a/files/nomad-extip-manager.py
+++ b/files/nomad-extip-manager.py
@@ -33,7 +33,6 @@ done
 
 ts=`date +%s`
 
-iptables -w -t nat -S POSTROUTING | head -n 2 | grep -F -- '-j EXTERNAL_IP' && exit 0 		#< If jump rule exists (at 1st position), we are done
 iptables -w -t nat -I POSTROUTING 1 -m comment --comment "NEIM:$ts" -j EXTERNAL_IP 			#< Insert jump to our target (at 1st position)
 while iptables -t nat -D POSTROUTING -j EXTERNAL_IP >/dev/null 2>&1; do :; done				#< Delete (potential) existing jump rule w/o signature
 

--- a/files/nomad-extip-manager.py
+++ b/files/nomad-extip-manager.py
@@ -33,7 +33,7 @@ done
 
 ts=`date +%s`
 
-if ! iptables -w -t nat -S POSTROUTING | head -n 2 | grep -F -- '-j EXTERNAL_IP'; then
+if ! iptables -w -t nat -S POSTROUTING | head -n 2 | grep -F -- '-j EXTERNAL_IP'; then			#< If jump rule exists (at 1st position), we are done, but let's create SNAT rules afterwards
 	iptables -w -t nat -I POSTROUTING 1 -m comment --comment "NEIM:$ts" -j EXTERNAL_IP 			#< Insert jump to our target (at 1st position)
 	while iptables -t nat -D POSTROUTING -j EXTERNAL_IP >/dev/null 2>&1; do :; done				#< Delete (potential) existing jump rule w/o signature
 


### PR DESCRIPTION
The previous validation we had makes the script exists whenever the EXTERNAL_IP rule is on top of POSTROUTING chain (no matter if it has signature or not).

That's a huge mistake given that we need to create the SNAT rules afterwards, and if docker or another job has created the EXTERNAL_IP on top of POSTROUTING we are avoiding to create the SNAT on EXTERNAL_IP chain